### PR TITLE
feat: add checkbox de lista de espera

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -96,6 +96,11 @@ function validaCPF(strCPF) {
   return true;
 }
 
+function onClickListaEspera() {
+  const checkbox = document.getElementById("check_fila_espera");
+  checkbox.checked = !checkbox.checked;
+}
+
 function validaCampo(field, errorField, type = 0) {
   if(type==0){
     if (field.value.length < 3) {

--- a/index.php
+++ b/index.php
@@ -52,6 +52,26 @@
                 <input type="hidden" name="ip" id="ip" value="<?php echo $_SERVER['REMOTE_ADDR'] ?>">
                 <div class="row g-3">
                     <!-- row -->
+                    <div class="form-group col-md-12" style="cursor: pointer" onclick="onClickListaEspera()">
+                        <div class="container" style="border: solid 1px; border-radius: 8px; padding: 15px;">
+                            <label style="padding-bottom: 10px; font-size: 20px; cursor: pointer"><b>Importante!</b></label>
+                            <div class="form-check">
+                                <input class="form-check-input"
+                                       type="checkbox"
+                                       value="1"
+                                       id="check_fila_espera"
+                                       name="check_fila_espera"
+                                       style="cursor: pointer"
+                                       required>
+                                <label class="form-check-label" for="check_fila_espera" style="cursor: pointer">
+                                    Entendo que estou entrando em uma <strong>lista de espera</strong> e que o
+                                    preenchimento dessa pré-ficha não significa que estarei automaticamente participando
+                                    do próximo acampamento. Compreendo que quando chegar a minha vez de participar,
+                                    alguém irá entrar em contato comigo por telefone.
+                                </label>
+                            </div>
+                        </div>
+                    </div>
                     <div class="form-group col-md-7">
                         <label for="name"><b>Nome Completo:</b></label>
                         <input type="text" class="form-control" id="name" placeholder="Nome Completo" name="name" onkeyup="validaCampo(this, 'name-error')" required>


### PR DESCRIPTION
Por solicitação do Padre, esse PR adiciona um aviso no topo do cadastro de pré-ficha, para deixar mais claro, desde o momento do preenchimento dos dados, que se trata de uma lista de espera:
![image](https://github.com/LucasGabrielFR/acamp-ficha/assets/7897981/1d702934-3d13-4c68-9030-450f93d596ef)
