### PR TITLE
Adiciona validação para 'is_spouse_camper'

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -181,7 +181,11 @@ function serializeForm() {
       !field.name.includes("familiar") &&
       !field.name.includes("relationship")
     ) {
-      if (field.name == "modality" || field.name == "is_baptized" || field.name == "is_eucharist" || field.name == "is_confirmed") {
+      if (field.name == "modality"
+          || field.name == "is_baptized"
+          || field.name == "is_eucharist"
+          || field.name == "is_confirmed"
+          || field.name == "is_spouse_camper") {
         if (field.checked) {
           params[field.name] = field.value;
         }


### PR DESCRIPTION
Inclui a nova chave 'is_spouse_camper' no bloco de validação condicional dentro da função JavaScript. Isso garante que o campo 'is_spouse_camper' seja corretamente processado quando estiver marcado.