### PR TITLE
Adiciona campo de gênero na validação de parâmetros

### DIFF
--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -200,7 +200,8 @@ function serializeForm() {
           || field.name == "is_baptized"
           || field.name == "is_eucharist"
           || field.name == "is_confirmed"
-          || field.name == "is_spouse_camper") {
+          || field.name == "is_spouse_camper"
+          || field.name == "gender") {
         if (field.checked) {
           params[field.name] = field.value;
         }


### PR DESCRIPTION
Inclui o campo "gender" na lista de parâmetros validados no arquivo functions.js. Isso garante que o parâmetro de gênero seja corretamente processado junto com outros campos como "is_baptized" e "is_spouse_camper".